### PR TITLE
Don't convert to smiles for smarts svg drawing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iktos-oss/molecule-representation",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@iktos-oss/molecule-representation",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
         "@visx/zoom": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.20.12",
-        "@iktos-oss/rdkit-provider": "^2.6.0",
+        "@iktos-oss/rdkit-provider": "^2.6.2",
         "@rdkit/rdkit": "^2023.9.2-1.0.0",
         "@storybook/addon-actions": "^6.5.16",
         "@storybook/addon-essentials": "^6.5.16",
@@ -49,7 +49,7 @@
         "typescript": "^4.9.4"
       },
       "peerDependencies": {
-        "@iktos-oss/rdkit-provider": "^2.6.0",
+        "@iktos-oss/rdkit-provider": "^2.6.2",
         "@rdkit/rdkit": "^2023.9.2-1.0.0",
         "react": ">=17.0.2",
         "react-dom": ">=17.0.2"
@@ -2294,9 +2294,9 @@
       "dev": true
     },
     "node_modules/@iktos-oss/rdkit-provider": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@iktos-oss/rdkit-provider/-/rdkit-provider-2.6.0.tgz",
-      "integrity": "sha512-kVPCl2IMvYzXEhmoYP+FxD9EtQycvHVCpEftgSnN0UlXOQgQHYD154b0MzeVDmZqmne6N+pBbjZyu72Wr+2BeA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@iktos-oss/rdkit-provider/-/rdkit-provider-2.6.2.tgz",
+      "integrity": "sha512-78/rUYnSxV7MTi8dAsqf/EMyx4xFXC66zD8rLFpcD4TAhBPuoVUxE05Dmp9Y7WHjzOCJ4fsySvx+FJqNfVmmZQ==",
       "dev": true,
       "peerDependencies": {
         "@rdkit/rdkit": "^2023.9.2-1.0.0",
@@ -39842,9 +39842,9 @@
       "dev": true
     },
     "@iktos-oss/rdkit-provider": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@iktos-oss/rdkit-provider/-/rdkit-provider-2.6.0.tgz",
-      "integrity": "sha512-kVPCl2IMvYzXEhmoYP+FxD9EtQycvHVCpEftgSnN0UlXOQgQHYD154b0MzeVDmZqmne6N+pBbjZyu72Wr+2BeA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@iktos-oss/rdkit-provider/-/rdkit-provider-2.6.2.tgz",
+      "integrity": "sha512-78/rUYnSxV7MTi8dAsqf/EMyx4xFXC66zD8rLFpcD4TAhBPuoVUxE05Dmp9Y7WHjzOCJ4fsySvx+FJqNfVmmZQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "author": "Ramzi Oueslati <ramzi.oueslati@iktos.com>",
   "devDependencies": {
     "@babel/core": "^7.20.12",
-    "@iktos-oss/rdkit-provider": "^2.6.0",
+    "@iktos-oss/rdkit-provider": "^2.6.2",
     "@rdkit/rdkit": "^2023.9.2-1.0.0",
     "@storybook/addon-actions": "^6.5.16",
     "@storybook/addon-essentials": "^6.5.16",
@@ -80,7 +80,7 @@
     "serve": "^14.2.0"
   },
   "peerDependencies": {
-    "@iktos-oss/rdkit-provider": "^2.6.0",
+    "@iktos-oss/rdkit-provider": "^2.6.2",
     "@rdkit/rdkit": "^2023.9.2-1.0.0",
     "react": ">=17.0.2",
     "react-dom": ">=17.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iktos-oss/molecule-representation",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "exports interactif molecule represnetations as react components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/src/utils/draw.ts
+++ b/src/utils/draw.ts
@@ -26,7 +26,6 @@ import {
   getMoleculeDetails,
   getCanonicalFormForStructure,
   getMatchingSubstructure,
-  convertMolNotation,
   getSvgFromSmarts,
   RDKitColor,
 } from '@iktos-oss/rdkit-provider';
@@ -94,17 +93,16 @@ export const get_svg_from_smarts = async (params: DrawSmartsSVGProps, worker: Wo
   if (!worker) return null;
   if (!params.smarts) return null;
 
-  const { structure } = await convertMolNotation(worker, {
-    moleculeString: params.smarts,
-    targetNotation: 'smarts',
+  const { canonicalForm: canonicalSmarts } = await getCanonicalFormForStructure(worker, {
+    structure: params.smarts,
     useQMol: true,
   });
 
-  if (!structure) return null;
+  if (!canonicalSmarts) return null;
 
   const { svg } = await getSvgFromSmarts(worker, {
     ...params,
-    smarts: structure,
+    smarts: canonicalSmarts,
   });
   return svg;
 };

--- a/src/utils/draw.ts
+++ b/src/utils/draw.ts
@@ -21,13 +21,14 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
 */
-
-import { RDKitColor, getSvgFromSmarts } from '@iktos-oss/rdkit-provider';
 import {
   getSvg,
   getMoleculeDetails,
   getCanonicalFormForStructure,
   getMatchingSubstructure,
+  convertMolNotation,
+  getSvgFromSmarts,
+  RDKitColor,
 } from '@iktos-oss/rdkit-provider';
 import { AlignmentDetails } from '../components';
 import { HIGHLIGHT_RDKIT_COLORS, TRANSPARANT_RDKIT_COLOR } from '../constants';
@@ -93,15 +94,17 @@ export const get_svg_from_smarts = async (params: DrawSmartsSVGProps, worker: Wo
   if (!worker) return null;
   if (!params.smarts) return null;
 
-  const { canonicalForm: canonicalSmarts } = await getCanonicalFormForStructure(worker, {
-    structure: params.smarts,
+  const { structure } = await convertMolNotation(worker, {
+    moleculeString: params.smarts,
+    targetNotation: 'smarts',
     useQMol: true,
   });
-  if (!canonicalSmarts) return null;
+
+  if (!structure) return null;
 
   const { svg } = await getSvgFromSmarts(worker, {
     ...params,
-    smarts: canonicalSmarts,
+    smarts: structure,
   });
   return svg;
 };


### PR DESCRIPTION
The example in storybook doesn't work.

For smarts `[#6][CH1](=O)`, it's doing a conversion to smiles `C[CH]=O`. `get_svg` is throwing an `Uncaught` error for this smarts and also the smiles when using `qmol`.

But, when doing a conversion `rdkit.get_qmol('[#6][CH1](=O)').get_smarts()`, it gives me this smarts `[#6][C&H1]=O`, and
`get_qmol('[#6][C&H1]=O').get_svg()` works. 

Another simpler example is `[n&H1]` and `[nH1]`. It should be the same smarts (see the doc here https://www.daylight.com/dayhtml/doc/theory/theory.smarts.html), but idk why, the second one doesn't work with rdkit-js for `get_svg`.